### PR TITLE
Adds license and download outputs

### DIFF
--- a/deploy/terraform/create-license.tf
+++ b/deploy/terraform/create-license.tf
@@ -8,6 +8,31 @@ resource "aws_secretsmanager_secret_version" "api_token" {
   secret_string = var.api_token
 }
 
+resource "aws_s3_bucket" "licenses" {
+  bucket = "slackernews-license-${random_pet.bucket_suffix.id}"
+
+}
+
+resource "aws_s3_bucket_ownership_controls" "licenses" {
+  bucket = aws_s3_bucket.licenses.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+resource "aws_s3_bucket_acl" "licenses" {
+  depends_on = [ aws_s3_bucket_ownership_controls.licenses ]
+
+  bucket = aws_s3_bucket.licenses.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_versioning" "licenses" {
+  bucket = aws_s3_bucket.licenses.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
 resource "aws_lambda_function" "create_license" {
   function_name = "create-replicated-license"
   architectures = ["arm64"]
@@ -19,20 +44,42 @@ resource "aws_lambda_function" "create_license" {
   filename         = "${var.build_directory}/create-license.zip"
   source_code_hash = filebase64sha256("${var.build_directory}/create-license.zip")
   
+  timeout = 6
+
   environment {
     variables = {
       SECRET_ARN = aws_secretsmanager_secret.api_token.arn
+      LICENSE_BUCKET_NAME = aws_s3_bucket.licenses.bucket
+      LICENSE_BUCKET_DOMAIN = aws_s3_bucket.licenses.bucket_regional_domain_name
     }
   }
 }
 
-resource "aws_iam_role_policy" "lambda_secretsmanager_policy" {
-  name   = "lambda_secretsmanager_policy"
-  role   = aws_iam_role.lambda_exec_role.id
-  policy = data.aws_iam_policy_document.lambda_secretsmanager_policy.json
+resource "aws_iam_policy" "lambda_license_bucket" {
+  name   = "lambda_license_bucket"
+  policy = data.aws_iam_policy_document.lambda_license_bucket.json
 }
 
-data "aws_iam_policy_document" "lambda_secretsmanager_policy" {
+data "aws_iam_policy_document" "lambda_license_bucket" {
+  statement {
+    actions   = [
+      "s3:ListBucket",
+      "s3:GetObject",
+      "s3:GetObjectVersion",
+      "s3:PutObject",
+      "s3:DeleteObject",
+      "s3:PutObject",
+    ]
+    resources = [ "${aws_s3_bucket.licenses.arn}/*" ]
+  }
+}
+
+resource "aws_iam_policy" "lambda_secrets_manager" {
+  name   = "lambda_secrets_manager"
+  policy = data.aws_iam_policy_document.lambda_secrets_manager.json
+}
+
+data "aws_iam_policy_document" "lambda_secrets_manager" {
   statement {
     actions   = ["secretsmanager:GetSecretValue"]
     resources = [aws_secretsmanager_secret.api_token.arn]
@@ -41,6 +88,16 @@ data "aws_iam_policy_document" "lambda_secretsmanager_policy" {
 
 data "aws_iam_policy" "lambda_exec_policy" {
   name = "AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_license_bucket" {
+  role       = aws_iam_role.lambda_exec_role.id
+  policy_arn = aws_iam_policy.lambda_license_bucket.arn
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_secrets_manager" {
+  role       = aws_iam_role.lambda_exec_role.id
+  policy_arn = aws_iam_policy.lambda_secrets_manager.arn
 }
 
 resource "aws_iam_role_policy_attachment" "lambda_exec_policy" {
@@ -64,5 +121,4 @@ resource "aws_iam_role" "lambda_exec_role" {
     ],
   })
 }
-
 

--- a/deploy/terraform/templates/slackernews_cloudformation.tftpl
+++ b/deploy/terraform/templates/slackernews_cloudformation.tftpl
@@ -44,3 +44,14 @@ Resources:
       AppId: ${app_id}
       Channel: !If [ IsBeta, Beta, Stable ]
       Type: !FindInMap [ LicenseType, !Ref SubscriptionType, Type ]
+
+Outputs:
+  InstallUri:
+    Description: URI for the embedded clustser download
+    Value: !GetAtt CreateLicense.InstallerUri
+  DownloadToken:
+    Description: Authorization token for installer download
+    Value: !GetAtt CreateLicense.DownloadToken
+  LicenseUri:
+    Description: URI of the Replicated license file
+    Value: !GetAtt CreateLicense.LicenseFileUri

--- a/src/create-license/app.py
+++ b/src/create-license/app.py
@@ -1,0 +1,52 @@
+import logging
+
+import requests
+
+logging.basicConfig()
+logger = logging.getLogger(__name__)
+
+
+class App:
+
+  def __init__(self, api_token, id=None):
+    self.api_token = api_token
+    if ( id is not None ): 
+      self.load(id)
+
+  def load(self,id):
+    logger.debug("loading app {id}".format(id=id))
+    get_app_url = "https://api.replicated.com/vendor/v3/app/{id}".format(id=id)
+
+    headers = {
+        "accept": "application/json",
+        "content-type": "application/json",
+        "authorization": self.api_token
+    } 
+
+    # Sending the payload to the external API
+    response = requests.get(get_app_url, headers=headers)
+    response.raise_for_status()
+    app_response = response.json()
+    self.__dict__ = self.__dict__ | app_response['app']
+    self.__dict__['api_host'] = self.__api_host()
+
+    logger.debug("loaded app {name} with id {id}".format(name=self.name,id=self.id))
+
+  def __api_host(self):
+    get_hostnames = "https://api.replicated.com/vendor/v3/app/{id}/custom-hostnames".format(id=self.id)
+
+    headers = {
+        "accept": "application/json",
+        "authorization": self.api_token
+    } 
+    # any processing of the event data here
+
+    # Sending the payload to the external API
+    response = requests.get(get_hostnames, headers=headers)
+    response.raise_for_status()
+
+    hostnames = response.json()['Body']
+    if not hostnames.get('replicatedApp'):
+      return 'replicated.app'
+    
+    return next(item for item in hostnames['replicatedApp'] if item['is_default'])['hostname']

--- a/src/create-license/main.py
+++ b/src/create-license/main.py
@@ -4,9 +4,11 @@ from crhelper import CfnResource
 import logging
 
 import boto3
-aws_client = boto3.client('secretsmanager')
+secrets_manager = boto3.client('secretsmanager')
+s3 = boto3.client('s3')
 
 from customer import Customer
+from app import App
 
 import datetime
 from dateutil.relativedelta import relativedelta
@@ -22,7 +24,7 @@ helper = CfnResource(
 
 def get_api_token():
   secret_arn = os.environ["SECRET_ARN"]
-  response = aws_client.get_secret_value(SecretId=secret_arn)
+  response = secrets_manager.get_secret_value(SecretId=secret_arn)
   return response['SecretString']
 
 def handler(event, context):
@@ -31,13 +33,33 @@ def handler(event, context):
 @helper.create
 def create(event, context):
     logger.info("creating resoource")
+
     api_token = get_api_token()
     properties = event.get('ResourceProperties')
+    logger.debug("Loading application")
+    app = App(api_token, properties.get('AppId'))
+
     expiration_date = datetime.date.today() + relativedelta(years=1)
     logger.debug("creating customer")
     customer = Customer.create(api_token, properties.get('Name'), properties.get('Email'),
-                               properties.get('AppId'), expiration_date, properties.get('Type'),
+                               app.id, expiration_date, properties.get('Type'),
                                properties.get('Channel'))  
+
+    license_id = customer.installationId
+    helper.Data.update({'DownloadToken': f'{license_id}'})
+
+    license_data = customer.license()
+    bucket_name = os.environ["LICENSE_BUCKET_NAME"]
+    bucket_domain = os.environ["LICENSE_BUCKET_DOMAIN"]
+    file_key = "{customer}.yaml".format(customer=customer.id)
+    logger.debug(f'saving license to file {file_key} in bucket {bucket_name}')
+    s3.put_object(Bucket=bucket_name, Key=file_key, Body=license_data)
+    helper.Data.update({'LicenseFileUri': f'https://{bucket_domain}/{file_key}'})
+
+    app_domain = app.api_host
+    slug = app.slug
+    channel = properties.get('Channel').lower()
+    helper.Data.update({'InstallerUri': f'https://{app_domain}/embedded/{slug}/{channel}'})
 
     return customer.id
 
@@ -49,5 +71,10 @@ def delete(event, context):
     properties = event.get('ResourceProperties')
 
     customer = Customer(api_token, properties.get('AppId'), customerId)
+
+    bucket_name = os.environ["LICENSE_BUCKET_NAME"]
+    file_key = "{customer}.yaml".format(customer=customer.id)
+    s3.delete_object(Bucket=bucket_name, Key=file_key)
+
     customer.remove()
 


### PR DESCRIPTION
TL;DR
-----

Provides the license and embedded cluster download info

Details
-------

Updates the create license functionality to store the license file
in S3 and provide outputs for the license file URI, embedded cluster
download URI, and the token required to download the EC tarball.
These changes set the license creation functionality up to be
incorporated into a broader CloudFormation template that installs
the application after creating the customer.